### PR TITLE
docs: Clean up duplicate README section and refine transform field description

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ When configuring client districts in `config.yaml`, the following keywords defin
 | `type` | Symphony field type (determines JSON structure sent to API). |
 | `overlay` | Boolean (`true`/`false`). Controls whether this field is updated when an existing patron record is modified. |
 | `validate` | Validation rule string applied to incoming CSV data. Invalid records trigger warnings and skipping. |
-| `transform` | Transformation function in `ingestor.pl` (e.g., `c:transform_street` or `c:transform_barcode`). |
+| `transform` | Transformation function in `ingestor.pl` (e.g., `c:transform_street`, `c:transform_barcode`, `c:transform_pin`, `c:transform_profile`) which takes input from incoming or existing record data and client configuration, returning a transformed value. |
 | `overlay_default` | Fallback value to insert during an update if the field in Symphony is currently empty. |
 | `overlay_value` | Static value that ALWAYS overwrites the field during an update. |
 | `new_default` | Fallback value to use during new patron creation if the field is empty in incoming data. |
@@ -362,37 +362,3 @@ Logging is driven by `Log::Log4perl` using the configuration in `log.conf`:
 - **Mail Summary Log**: Generated per run at `/opt/librelibconnected/log/mail.log` and attached to report emails.
 - **CSV Audit Log**: Generated per run at `/opt/librelibconnected/log/ingestor.csv` detailing actions taken (`create`, `update`, `skip`) for each record.
 - **Email Notification**: On completion, `ingestor.pl` compiles the run statistics and emails `mail.log` and `ingestor.csv` via `MIME::Lite`.
-# Configuration Notes
-
-## Field Definition Keywords
-When configuring client districts, a number of keywords may be used 
-to define the way the software will handle incoming data and derivative fields:
-* `type`: Symphony field type (used to determine data structure needed in JSON)
-* `overlay`: If true, update field when updating existing record
-* `validate`: Field validation rule to apply to incoming data (ingestor will throw error and skip record if validation fails)
-* `transform`: Transformation function (in ingestor.pl) which takes validated input from one or more fields in the incoming or existing record data and returns a valid value
-* `overlay_default`: Value to use in update IF FIELD CURRENTLY EMPTY
-* `overlay_value`: Value to ALWAYS overlay existing value during update
-* `new_default`: Value to use in create IF FIELD CURRENTLY EMPTY
-* `new_value`: Value to be used during new create
-
-## Validation Rules
-
-Sample validation rules used in conjunction with the validate field definition keyword:
-| Type           | Example              | Comments                 |
-| ---            | ---                  | ---                      |
-| Date1          | "d:YYYY-MM-DD"       |                          |
-| Date2          | "d:YYYY/MM/DD"       |                          |
-| Date3          | "d:MM-DD-YYYY"       |                          |
-| Date4          | "d:MM/DD/YYYY"       |                          |
-| Timestamp1     | "d:YYYY/MM/DD HH:MM" |                          |
-| Timestamp2     | "d:YYYY-MM-DD HH:MM" |                          |
-| Timestamp3     | "d:YYYYMMDDHHMMSS"   |                          |
-| Integer        | "i:8"                | Length of 8              |
-| String         | "s:256"              | Max length of 256        |
-| List           | "v:01\|11"            | Pipe delimited list of valid entries |
-| Blank          | "b"                  | Must be blank            |
-| Decimal number | "n:3.2"              | Number(000.00)           |
-| Integer range  | "r:1,9999"           | Range between 1 and 9999 |
-
-Note: All dates will be validated against the calendar


### PR DESCRIPTION
This PR cleans up leftover unformatted sections from a previous merge conflict in  and refines the  keyword description.

### Changes:
1. **Removed Leftover Section**: Removed duplicate unformatted Configuration Notes section at the bottom of  resulting from conflict resolution when  was merged into .
2. **Refined Description**: Enhanced  keyword explanation in the Field Definition Keywords table to reflect its ability to process incoming data, existing Symphony patron records, and district configuration.